### PR TITLE
explicitly use python 3 pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ That one is pretty easy:
 
 .. code:: shell
 
-    $ pip install discurses
+    $ pip3 install discurses
 
 Python 3.6 or more is required.
 


### PR DESCRIPTION
This merge request explicitly uses python 3 pip in order to download the package.